### PR TITLE
correction of LOGFILE for all OS

### DIFF
--- a/ttclust-GUI.py
+++ b/ttclust-GUI.py
@@ -135,8 +135,8 @@ if __name__ == '__main__':
               "into {}.bak".format(logname))
         os.makedirs(logname)    
 
-    args["logfile"] = os.path.basename(args["logfile"]) 
-    LOGFILE=open("{0}/{1}".format(logname,args["logfile"]),"w")
+    filename = args["logfile"].split(os.sep)[-1]
+    LOGFILE=open("{0}/{1}".format(logname,filename),"w")
     ttclust.define_LOGFILE(LOGFILE)
     ttclust.Cluster_analysis_call(args)
     LOGFILE.close()


### PR DESCRIPTION
use split() function and os.sep instead of os.path.basename()